### PR TITLE
add ignore raycaster on entity with special attribute

### DIFF
--- a/src/lib/raycaster.js
+++ b/src/lib/raycaster.js
@@ -9,7 +9,8 @@ export function initRaycaster(inspector) {
   mouseCursor.setAttribute('data-aframe-inspector', 'true');
   mouseCursor.setAttribute('raycaster', {
     interval: 100,
-    objects: 'a-scene :not([data-aframe-inspector])'
+    objects:
+      'a-scene :not([data-aframe-inspector]):not([data-ignore-raycaster])'
   });
 
   // Only visible objects.


### PR DESCRIPTION
Add the data-ignore-raycaster attribute to the entity to use raycaster ignore. To work with env-sky I will add a separate PR to 3DStreet repo: https://github.com/3DStreet/3dstreet/pull/312