### PR TITLE
Fix duplicate entity feature not using the modified value for position/rotation/scale

### DIFF
--- a/src/components/components/Mixins.js
+++ b/src/components/components/Mixins.js
@@ -63,7 +63,9 @@ export default class Mixin extends React.Component {
 
     this.setState({ mixins: value });
     const mixinStr = value.value;
-    // hack to fix error that sometimes a newly selected model won't load
+    // Remove the current mixin first so that it removes the gltf-model
+    // component, then set the new mixin that will load a new gltf model.
+    // If we don't remove first, sometimes a newly selected model won't load.
     entity.setAttribute('mixin', '');
     entity.setAttribute('mixin', value.value);
 

--- a/src/lib/entity.js
+++ b/src/lib/entity.js
@@ -125,10 +125,9 @@ function insertAfter(newNode, referenceNode) {
  * @param  {Element} entity Entity to clone
  */
 export function cloneEntity(entity) {
-  // TODO: flushToDOM resets to state of entity prior to opening inspector see https://github.com/aframevr/aframe-inspector/issues/688
   entity.flushToDOM();
 
-  const clone = entity.cloneNode(true);
+  const clone = prepareForSerialization(entity);
   clone.addEventListener('loaded', function () {
     AFRAME.INSPECTOR.selectEntity(clone);
     Events.emit('entityclone');
@@ -139,11 +138,6 @@ export function cloneEntity(entity) {
     clone.id = getUniqueId(entity.id);
   }
   insertAfter(clone, entity);
-  // TODO: Hack for if entity has mixin to ensure that it displays correctly upon clone
-  if (entity.hasAttribute('mixin')) {
-    clone.setAttribute('mixin', '');
-    clone.setAttribute('mixin', entity.getAttribute('mixin'));
-  }
 }
 
 /**

--- a/src/lib/viewport.js
+++ b/src/lib/viewport.js
@@ -124,6 +124,11 @@ export function Viewport(inspector) {
       component = 'scale';
       value = `${object.scale.x} ${object.scale.y} ${object.scale.z}`;
     }
+
+    // We need to call setAttribute for component attrValue to be up to date,
+    // so that entity.flushToDOM() works correctly when duplicating an entity.
+    transformControls.object.el.setAttribute(component, value);
+
     Events.emit('entityupdate', {
       component: component,
       entity: transformControls.object.el,


### PR DESCRIPTION
Same PR than aframe-inspector https://github.com/aframevr/aframe-inspector/pull/695 but on your repo. This fixes #186

Properly call `setAttribute` for position, rotation, scale when modifying with the TransformControls, so that `entity.flushToDOM()` works correctly when duplicating an entity.
This fixes https://github.com/aframevr/aframe-inspector/issues/688
See my comment https://github.com/aframevr/aframe-inspector/issues/688#issuecomment-1646632546 for a more detailed explanation of the issue and the proposed fix.