### PR TITLE
Cherry pick open modal listing scenes owned by me (issue #222)

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -4,3 +4,5 @@ export {
   userFindByUidQuery,
   getScenes
 } from './user';
+
+export { getUserScenes, uploadScene } from './scene';

--- a/src/api/scene.js
+++ b/src/api/scene.js
@@ -1,4 +1,11 @@
-import { collection, doc, setDoc } from 'firebase/firestore';
+import {
+  collection,
+  doc,
+  setDoc,
+  getDocs,
+  query,
+  where
+} from 'firebase/firestore';
 import { db } from '../services/firebase';
 
 const uploadScene = async (
@@ -22,4 +29,17 @@ const uploadScene = async (
     console.error(error);
   }
 };
-export { uploadScene };
+
+const getUserScenes = async (currentUserUID) => {
+  const userScenesQuery = query(
+    collection(db, 'scenes'),
+    where('author', '==', currentUserUID)
+  );
+
+  const scenesSnapshot = await getDocs(userScenesQuery);
+  const scenesData = scenesSnapshot.docs.map((doc) => doc.data());
+
+  return scenesData;
+};
+
+export { uploadScene, getUserScenes };

--- a/src/api/scene.js
+++ b/src/api/scene.js
@@ -4,7 +4,8 @@ import {
   setDoc,
   getDocs,
   query,
-  where
+  where,
+  onSnapshot
 } from 'firebase/firestore';
 import { db } from '../services/firebase';
 
@@ -42,4 +43,18 @@ const getUserScenes = async (currentUserUID) => {
   return scenesData;
 };
 
-export { uploadScene, getUserScenes };
+const subscribeToUserScenes = (currentUserUID, onUpdate) => {
+  const userScenesQuery = query(
+    collection(db, 'scenes'),
+    where('author', '==', currentUserUID)
+  );
+
+  const unsubscribe = onSnapshot(userScenesQuery, (querySnapshot) => {
+    const scenesData = querySnapshot.docs.map((doc) => doc.data());
+    onUpdate(scenesData);
+  });
+
+  return unsubscribe;
+};
+
+export { uploadScene, getUserScenes, subscribeToUserScenes };

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -1,5 +1,4 @@
 import { Button, HelpButton, Logo, ZoomButtons } from './components';
-
 import { CameraToolbar } from './viewport';
 import { Compass32Icon } from '../icons';
 import { Component } from 'react';
@@ -14,31 +13,28 @@ import TransformToolbar from './viewport/TransformToolbar';
 import { injectCSS } from '../lib/utils';
 import { SignInModal } from './modals/SignInModal';
 import { ProfileModal } from './modals/ProfileModal';
-
+import { ScenesModal } from './modals/ScenesModal';
 THREE.ImageUtils.crossOrigin = '';
-
 // Megahack to include font-awesome.
 injectCSS(
   'https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css'
 );
-
 export default class Main extends Component {
   constructor(props) {
     super(props);
-
     this.state = {
       entity: null,
       inspectorEnabled: true,
       isModalTexturesOpen: false,
       isSignInModalOpened: false,
       isProfileModalOpened: false,
+      isScenesModalOpened: false,
       sceneEl: AFRAME.scenes[0],
       visible: {
         scenegraph: true,
         attributes: true
       }
     };
-
     Events.on('togglesidebar', (event) => {
       if (event.which === 'all') {
         if (this.state.visible.scenegraph || this.state.visible.attributes) {
@@ -78,9 +74,7 @@ export default class Main extends Component {
     const htmlEditorButton = document?.querySelector(
       '.viewer-logo-start-editor-button'
     );
-
     htmlEditorButton && htmlEditorButton.remove();
-
     Events.on(
       'opentexturesmodal',
       function (selectedTexture, textureOnClose) {
@@ -91,15 +85,12 @@ export default class Main extends Component {
         });
       }.bind(this)
     );
-
     Events.on('entityselect', (entity) => {
       this.setState({ entity: entity });
     });
-
     Events.on('inspectortoggle', (enabled) => {
       this.setState({ inspectorEnabled: enabled });
     });
-
     Events.on('openhelpmodal', () => {
       this.setState({ isHelpOpen: true });
     });
@@ -108,6 +99,9 @@ export default class Main extends Component {
     });
     Events.on('opensigninmodal', () => {
       this.setState({ isSignInModalOpened: true });
+    });
+    Events.on('openscenesmodal', () => {
+      this.setState({ isScenesModalOpened: true });
     });
     Events.on('openprofilemodal', () => {
       this.setState({ isProfileModalOpened: true });
@@ -133,6 +127,10 @@ export default class Main extends Component {
     this.setState({ isSignInModalOpened: false });
   };
 
+  onCloseScenesModal = () => {
+    this.setState({ isScenesModalOpened: false });
+  };
+
   onCloseProfileModal = () => {
     this.setState({ isProfileModalOpened: false });
   };
@@ -153,6 +151,7 @@ export default class Main extends Component {
     ) {
       return null;
     }
+
     return (
       <div className="toggle-sidebar right">
         <a
@@ -186,14 +185,11 @@ export default class Main extends Component {
   render() {
     const scene = this.state.sceneEl;
     const isEditor = !!this.state.inspectorEnabled;
-
     return (
       <div>
         <Logo onToggleEdit={this.toggleEdit} isEditor={isEditor} />
-
         {this.renderSceneGraphToggle()}
         {this.renderComponentsToggle()}
-
         {isEditor && (
           <div id="inspectorContainer">
             <SceneGraph
@@ -201,12 +197,10 @@ export default class Main extends Component {
               selectedEntity={this.state.entity}
               visible={this.state.visible.scenegraph}
             />
-
             <div id="viewportBar">
               <CameraToolbar />
               <TransformToolbar />
             </div>
-
             <div id="rightPanel">
               <ComponentsSidebar
                 entity={this.state.entity}
@@ -215,7 +209,6 @@ export default class Main extends Component {
             </div>
           </div>
         )}
-
         <ModalHelp
           isOpen={this.state.isHelpOpen}
           onClose={this.onCloseHelpModal}
@@ -227,6 +220,10 @@ export default class Main extends Component {
         <SignInModal
           isOpen={this.state.isSignInModalOpened}
           onClose={this.onCloseSignInModal}
+        />
+        <ScenesModal
+          isOpen={this.state.isScenesModalOpened}
+          onClose={this.onCloseScenesModal}
         />
         <ProfileModal
           isOpen={this.state.isProfileModalOpened}
@@ -242,13 +239,11 @@ export default class Main extends Component {
             <HelpButton />
           </div>
         )}
-
         {this.state.inspectorEnabled && (
           <div id={'zoom-buttons'}>
             <ZoomButtons />
           </div>
         )}
-
         {this.state.inspectorEnabled && (
           <Button id={'resetZoomButton'}>
             <Compass32Icon />

--- a/src/components/components/Button/Button.module.scss
+++ b/src/components/components/Button/Button.module.scss
@@ -51,6 +51,10 @@
     color: rgba(50, 50, 50, 0.4);
     transition: all 0.3s;
   }
+
+  &:focus {
+    border: 1px solid #fff;
+  }
 }
 
 .outlinedButton {
@@ -68,6 +72,10 @@
     color: #5b37c0;
     border-color: #5b37c0;
     transition: all 0.3s;
+  }
+
+  &:focus {
+    border: 1px solid #fff;
   }
 
   &:disabled {

--- a/src/components/components/Input/Input.module.scss
+++ b/src/components/components/Input/Input.module.scss
@@ -22,7 +22,7 @@
     column-gap: 0.5rem;
     width: calc(100% - 30px);
     white-space: nowrap;
-    padding: 13px 13px 13px 15px;
+    padding: 8px 12px;
     border: 1px solid #543e79;
     border-radius: 10px;
     background-color: rgba(50, 50, 50, 0.8);

--- a/src/components/components/SceneCard/SceneCard.component.jsx
+++ b/src/components/components/SceneCard/SceneCard.component.jsx
@@ -9,6 +9,7 @@ const SceneCard = ({ scenesData, handleSceneClick }) => (
         key={index}
         className={styles.card}
         onClick={() => handleSceneClick(scene)}
+        title={scene.title}
       >
         <img src={Scene} alt="scene" className={styles.img} />
         <p style={{ fontSize: '16px' }} className={styles.title}>

--- a/src/components/components/SceneCard/SceneCard.component.jsx
+++ b/src/components/components/SceneCard/SceneCard.component.jsx
@@ -2,10 +2,14 @@ import React from 'react';
 import Scene from '../../../../assets/scene.svg';
 import styles from './SceneCard.module.scss';
 
-const SceneCard = ({ scenesData }) => (
+const SceneCard = ({ scenesData, handleSceneClick }) => (
   <div className={styles.wrapper}>
     {scenesData.map((scene, index) => (
-      <div key={index} className={styles.card}>
+      <div
+        key={index}
+        className={styles.card}
+        onClick={() => handleSceneClick(scene)}
+      >
         <img src={Scene} alt="scene" className={styles.img} />
         <p style={{ fontSize: '16px' }} className={styles.title}>
           {scene.title}

--- a/src/components/components/SceneCard/SceneCard.component.jsx
+++ b/src/components/components/SceneCard/SceneCard.component.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Scene from '../../../../assets/scene.svg';
+import styles from './SceneCard.module.scss';
+
+const SceneCard = ({ scenesData }) => (
+  <div className={styles.wrapper}>
+    {scenesData.map((scene, index) => (
+      <div key={index} className={styles.card}>
+        <img src={Scene} alt="scene" className={styles.img} />
+        <p style={{ fontSize: '16px' }} className={styles.title}>
+          {scene.title}
+        </p>
+      </div>
+    ))}
+  </div>
+);
+
+export { SceneCard };

--- a/src/components/components/SceneCard/SceneCard.module.scss
+++ b/src/components/components/SceneCard/SceneCard.module.scss
@@ -1,17 +1,21 @@
 .wrapper {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
   row-gap: 24px;
   column-gap: 20px;
+  overflow-y: scroll;
+  height: 100%;
+
   .img {
     margin-bottom: 12px;
   }
+
   .card {
     border-radius: 4px;
     border: 1px solid rgba(237, 235, 239, 0.2);
     padding: 8px 8px 12px 8px;
   }
+
   .title {
     font-weight: 600;
     text-overflow: ellipsis;

--- a/src/components/components/SceneCard/SceneCard.module.scss
+++ b/src/components/components/SceneCard/SceneCard.module.scss
@@ -1,10 +1,9 @@
 .wrapper {
   display: flex;
   flex-wrap: wrap;
+  justify-content: flex-start;
   row-gap: 24px;
   column-gap: 20px;
-  overflow-y: scroll;
-  height: 100%;
 
   .img {
     margin-bottom: 12px;
@@ -14,6 +13,22 @@
     border-radius: 4px;
     border: 1px solid rgba(237, 235, 239, 0.2);
     padding: 8px 8px 12px 8px;
+    cursor: pointer;
+
+    &:hover {
+      border: 1px solid #6439df;
+      transition: ease-out 0.3s;
+    }
+
+    &:active {
+      border-color: #5b37c0;
+      transition: all 0.3s;
+    }
+
+    &:disabled {
+      border: 1px solid rgba(237, 235, 239, 0.5);
+      transition: all 0.3s;
+    }
   }
 
   .title {

--- a/src/components/components/SceneCard/SceneCard.module.scss
+++ b/src/components/components/SceneCard/SceneCard.module.scss
@@ -1,0 +1,20 @@
+.wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  row-gap: 24px;
+  column-gap: 20px;
+  .img {
+    margin-bottom: 12px;
+  }
+  .card {
+    border-radius: 4px;
+    border: 1px solid rgba(237, 235, 239, 0.2);
+    padding: 8px 8px 12px 8px;
+  }
+  .title {
+    font-weight: 600;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+}

--- a/src/components/components/SceneCard/SceneCard.module.scss
+++ b/src/components/components/SceneCard/SceneCard.module.scss
@@ -13,6 +13,9 @@
     border-radius: 4px;
     border: 1px solid rgba(237, 235, 239, 0.2);
     padding: 8px 8px 12px 8px;
+    width: 262px;
+    height: 195px;
+    position: relative;
     cursor: pointer;
 
     &:hover {
@@ -35,5 +38,6 @@
     font-weight: 600;
     text-overflow: ellipsis;
     overflow: hidden;
+    white-space: nowrap;
   }
 }

--- a/src/components/components/SceneCard/index.js
+++ b/src/components/components/SceneCard/index.js
@@ -1,0 +1,1 @@
+export { SceneCard } from './SceneCard.component.jsx';

--- a/src/components/components/index.js
+++ b/src/components/components/index.js
@@ -9,3 +9,4 @@ export { Toggle } from './Toggle';
 export { Logo } from './Logo';
 export { ScreenshotButton } from './ScreenshotButton';
 export { ProfileButton } from './ProfileButton';
+export { SceneCard } from './SceneCard';

--- a/src/components/modals/Modal.jsx
+++ b/src/components/modals/Modal.jsx
@@ -4,7 +4,9 @@ import React, { Component } from 'react';
 
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Cross24Icon } from '../../icons';
+import { Cross24Icon, Mangnifier20Icon } from '../../icons';
+import { Input } from '../components/Input/Input.component.jsx';
+import { Button } from '../components/Button/Button.component.jsx';
 
 export default class Modal extends Component {
   static propTypes = {
@@ -102,19 +104,38 @@ export default class Modal extends Component {
         className={classNames('modal', !this.state.isOpen && 'hide')}
       >
         <div className={classNames('modal-content', className)} ref={this.self}>
-          <div className="modal-header">
+          <div
+            className={classNames(
+              title === 'Open scene' ? 'modal-scene-header' : 'modal-header'
+            )}
+          >
             <span className="close" onClick={this.close}>
-              {/* <span />
-              <span /> */}
               <Cross24Icon />
             </span>
             {typeof titleElement !== 'undefined' ? (
               titleElement
             ) : (
-              <h3>{title}</h3>
+              <h3 className={'title'}>{title}</h3>
+            )}
+            {title === 'Open scene' && (
+              <div className="header">
+                <Input
+                  className="input"
+                  placeholder="Search"
+                  leadingIcon={<Mangnifier20Icon />}
+                />
+                <div className="buttons">
+                  <Button className="loadBtn">Load new scene</Button>
+                  <Button className="createScene" variant="outlined">
+                    Create new scene
+                  </Button>
+                </div>
+              </div>
             )}
           </div>
-          <div className="modal-body">{children}</div>
+          <div className={'Open scene' ? 'modal-scene' : 'modal-body'}>
+            {children}
+          </div>
         </div>
       </div>
     );

--- a/src/components/modals/Modal.jsx
+++ b/src/components/modals/Modal.jsx
@@ -4,9 +4,7 @@ import React, { Component } from 'react';
 
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Cross24Icon, Mangnifier20Icon } from '../../icons';
-import { Input } from '../components/Input/Input.component.jsx';
-import { Button } from '../components/Button/Button.component.jsx';
+import { Cross24Icon } from '../../icons';
 
 export default class Modal extends Component {
   static propTypes = {
@@ -105,9 +103,10 @@ export default class Modal extends Component {
       >
         <div className={classNames('modal-content', className)} ref={this.self}>
           <div
-            className={classNames(
-              title === 'Open scene' ? 'modal-scene-header' : 'modal-header'
-            )}
+            // className={classNames(
+            //   title === 'Open scene' ? 'modal-scene-header' : 'modal-header'
+            // )}
+            className="modal-header"
           >
             <span className="close" onClick={this.close}>
               <Cross24Icon />
@@ -117,7 +116,7 @@ export default class Modal extends Component {
             ) : (
               <h3 className={'title'}>{title}</h3>
             )}
-            {title === 'Open scene' && (
+            {/* {title === 'Open scene' && (
               <div className="header">
                 <Input
                   className="input"
@@ -131,11 +130,9 @@ export default class Modal extends Component {
                   </Button>
                 </div>
               </div>
-            )}
+            )} */}
           </div>
-          <div className={'Open scene' ? 'modal-scene' : 'modal-body'}>
-            {children}
-          </div>
+          <div className={'modal-body'}>{children}</div>
         </div>
       </div>
     );

--- a/src/components/modals/Modal.jsx
+++ b/src/components/modals/Modal.jsx
@@ -1,7 +1,5 @@
 import './Modal.styles.styl';
-
 import React, { Component } from 'react';
-
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Cross24Icon } from '../../icons';
@@ -95,7 +93,8 @@ export default class Modal extends Component {
 
   render() {
     const { children, id, title, titleElement, className } = this.props;
-
+    const modalClassName =
+      title === 'Open scene' ? 'modal-scene' : 'modal-body';
     return (
       <div
         id={id}
@@ -103,10 +102,9 @@ export default class Modal extends Component {
       >
         <div className={classNames('modal-content', className)} ref={this.self}>
           <div
-            // className={classNames(
-            //   title === 'Open scene' ? 'modal-scene-header' : 'modal-header'
-            // )}
-            className="modal-header"
+            className={classNames(
+              title === 'Open scene' ? 'modal-scene-header' : 'modal-header'
+            )}
           >
             <span className="close" onClick={this.close}>
               <Cross24Icon />
@@ -114,25 +112,19 @@ export default class Modal extends Component {
             {typeof titleElement !== 'undefined' ? (
               titleElement
             ) : (
-              <h3 className={'title'}>{title}</h3>
+              <h3
+                style={{
+                  fontSize: '20px',
+                  marginTop: '26px',
+                  marginBottom: '0px',
+                  position: 'relative'
+                }}
+              >
+                {title}
+              </h3>
             )}
-            {/* {title === 'Open scene' && (
-              <div className="header">
-                <Input
-                  className="input"
-                  placeholder="Search"
-                  leadingIcon={<Mangnifier20Icon />}
-                />
-                <div className="buttons">
-                  <Button className="loadBtn">Load new scene</Button>
-                  <Button className="createScene" variant="outlined">
-                    Create new scene
-                  </Button>
-                </div>
-              </div>
-            )} */}
           </div>
-          <div className={'modal-body'}>{children}</div>
+          <div className={modalClassName}>{children}</div>
         </div>
       </div>
     );

--- a/src/components/modals/Modal.styles.styl
+++ b/src/components/modals/Modal.styles.styl
@@ -17,21 +17,3 @@
   width: 262px;
   height: 36px;
 }
-
-.title {
-  font-size: 20px;
-  margin-top: 26px;
-  margin-bottom: 0px;
-  position: relative;
-}
-
-.header {
-  display: flex;
-  justify-content: space-between;
-  margin: 24px 0px 0px 0px;
-}
-
-.buttons {
-  display: flex;
-  column-gap: 16px;
-}

--- a/src/components/modals/Modal.styles.styl
+++ b/src/components/modals/Modal.styles.styl
@@ -1,11 +1,37 @@
-.close:hover 
-  border-radius: 50%
-  cursor pointer
-  background-color rgba(50, 50, 50, 0.6)
-  transition all 0.3s
+.close:hover {
+  border-radius: 50%;
+  cursor: pointer;
+  background-color: rgba(50, 50, 50, 0.6);
+  transition: all 0.3s;
+}
 
-.close:active 
+.close:active {
   background-color: #282828;
 
-  span
-    background-color: #B6B6B6
+  span {
+    background-color: #B6B6B6;
+  }
+}
+
+.input {
+  width: 262px;
+  height: 36px;
+}
+
+.title {
+  font-size: 20px;
+  margin-top: 26px;
+  margin-bottom: 0px;
+  position: relative;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  margin: 24px 0px 0px 0px;
+}
+
+.buttons {
+  display: flex;
+  column-gap: 16px;
+}

--- a/src/components/modals/ScenesModal/ScenesModal.component.jsx
+++ b/src/components/modals/ScenesModal/ScenesModal.component.jsx
@@ -1,30 +1,25 @@
 import { collection, getDocs, query, where } from 'firebase/firestore';
 import React, { useEffect, useState } from 'react';
 import { useAuthContext } from '../../../contexts';
-import { db } from '../../../services/firebase';
-import { SceneCard } from '../../components/SceneCard/SceneCard.component.jsx';
+import { SceneCard, Input, Button } from '../../components';
 import Modal from '../Modal.jsx';
 import styles from './ScenesModal.module.scss';
+import { getUserScenes } from '../../../api';
+import { Mangnifier20Icon } from '../../../icons';
 
 const ScenesModal = ({ isOpen, onClose }) => {
   const { currentUser } = useAuthContext();
   const [scenesData, setScenesData] = useState([]);
+  const [sceneTitle, setSceneTitle] = useState('');
+
+  const fetchScenesData = async () => {
+    if (currentUser) {
+      const scenesData = await getUserScenes(currentUser.uid);
+      setScenesData(scenesData);
+    }
+  };
 
   useEffect(() => {
-    const fetchScenesData = async () => {
-      if (currentUser) {
-        const userScenesQuery = query(
-          collection(db, 'scenes'),
-          where('author', '==', currentUser.uid)
-        );
-
-        const scenesSnapshot = await getDocs(userScenesQuery);
-        const scenesData = scenesSnapshot.docs.map((doc) => doc.data());
-
-        setScenesData(scenesData);
-      }
-    };
-
     fetchScenesData();
   }, [currentUser]);
 
@@ -37,9 +32,25 @@ const ScenesModal = ({ isOpen, onClose }) => {
       title="Open scene"
     >
       <div className={styles.contentWrapper}>
-        <div className={styles.scrollContainer}>
-          <SceneCard scenesData={scenesData} />
+        <div className={styles.header}>
+          <Input
+            onChange={(value) => setSceneTitle(value)}
+            className="input"
+            placeholder="Search"
+            leadingIcon={<Mangnifier20Icon />}
+          />
+          <div className={styles.buttons}>
+            <Button className="loadBtn">Load new scene</Button>
+            <Button className="createScene" variant="outlined">
+              Create new scene
+            </Button>
+          </div>
         </div>
+        <SceneCard
+          scenesData={scenesData.filter(({ title }) =>
+            sceneTitle === '' ? true : title.includes(sceneTitle)
+          )}
+        />
       </div>
     </Modal>
   );

--- a/src/components/modals/ScenesModal/ScenesModal.component.jsx
+++ b/src/components/modals/ScenesModal/ScenesModal.component.jsx
@@ -28,6 +28,7 @@ const ScenesModal = ({ isOpen, onClose }) => {
   const handleSceneClick = (scene) => {
     if (scene && scene.data) {
       createElementsForScenesFromJSON(scene.data);
+      window.location.hash = `#/scenes/${scene.uuid}.json`;
       onClose();
     } else {
       console.error('Scene data is undefined or invalid');

--- a/src/components/modals/ScenesModal/ScenesModal.component.jsx
+++ b/src/components/modals/ScenesModal/ScenesModal.component.jsx
@@ -1,0 +1,48 @@
+import { collection, getDocs, query, where } from 'firebase/firestore';
+import React, { useEffect, useState } from 'react';
+import { useAuthContext } from '../../../contexts';
+import { db } from '../../../services/firebase';
+import { SceneCard } from '../../components/SceneCard/SceneCard.component.jsx';
+import Modal from '../Modal.jsx';
+import styles from './ScenesModal.module.scss';
+
+const ScenesModal = ({ isOpen, onClose }) => {
+  const { currentUser } = useAuthContext();
+  const [scenesData, setScenesData] = useState([]);
+
+  useEffect(() => {
+    const fetchScenesData = async () => {
+      if (currentUser) {
+        const userScenesQuery = query(
+          collection(db, 'scenes'),
+          where('author', '==', currentUser.uid)
+        );
+
+        const scenesSnapshot = await getDocs(userScenesQuery);
+        const scenesData = scenesSnapshot.docs.map((doc) => doc.data());
+
+        setScenesData(scenesData);
+      }
+    };
+
+    fetchScenesData();
+  }, [currentUser]);
+
+  return (
+    <Modal
+      className={styles.modalWrapper}
+      isOpen={isOpen}
+      onClose={onClose}
+      extraCloseKeyCode={72}
+      title="Open scene"
+    >
+      <div className={styles.contentWrapper}>
+        <div className={styles.scrollContainer}>
+          <SceneCard scenesData={scenesData} />
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export { ScenesModal };

--- a/src/components/modals/ScenesModal/ScenesModal.component.jsx
+++ b/src/components/modals/ScenesModal/ScenesModal.component.jsx
@@ -30,8 +30,16 @@ const ScenesModal = ({ isOpen, onClose }) => {
       createElementsForScenesFromJSON(scene.data);
       window.location.hash = `#/scenes/${scene.uuid}.json`;
       onClose();
+      AFRAME.scenes[0].components['notify'].message(
+        'Scene loaded from 3DStreet Cloud.',
+        'success'
+      );
     } else {
-      console.error('Scene data is undefined or invalid');
+      AFRAME.scenes[0].components['notify'].message(
+        'Error trying to load 3DStreet scene from cloud. Error: Scene data is undefined or invalid.',
+        'error'
+      );
+      console.error('Scene data is undefined or invalid.');
     }
   };
 

--- a/src/components/modals/ScenesModal/ScenesModal.module.scss
+++ b/src/components/modals/ScenesModal/ScenesModal.module.scss
@@ -1,3 +1,21 @@
+.contentWrapper {
+  display: flex;
+  flex-direction: column;
+  row-gap: 36px;
+  padding: 0 35px;
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    margin: 24px 0px 0px 0px;
+  }
+
+  .buttons {
+    display: flex;
+    column-gap: 16px;
+  }
+}
+
 .modalWrapper {
   position: relative;
   width: 1196px;

--- a/src/components/modals/ScenesModal/ScenesModal.module.scss
+++ b/src/components/modals/ScenesModal/ScenesModal.module.scss
@@ -1,0 +1,5 @@
+.modalWrapper {
+  position: relative;
+  width: 1196px;
+  margin: auto auto;
+}

--- a/src/components/modals/ScenesModal/ScenesModal.module.scss
+++ b/src/components/modals/ScenesModal/ScenesModal.module.scss
@@ -1,5 +1,5 @@
 .modalWrapper {
   position: relative;
-  width: 1196px;
+  width: 80vw;
   margin: auto auto;
 }

--- a/src/components/modals/ScenesModal/ScenesModal.module.scss
+++ b/src/components/modals/ScenesModal/ScenesModal.module.scss
@@ -1,21 +1,3 @@
-.contentWrapper {
-  display: flex;
-  flex-direction: column;
-  row-gap: 36px;
-  padding: 0 35px;
-
-  .header {
-    display: flex;
-    justify-content: space-between;
-    margin: 24px 0px 0px 0px;
-  }
-
-  .buttons {
-    display: flex;
-    column-gap: 16px;
-  }
-}
-
 .modalWrapper {
   position: relative;
   width: 1196px;

--- a/src/components/modals/ScenesModal/index.js
+++ b/src/components/modals/ScenesModal/index.js
@@ -1,0 +1,1 @@
+export { ScenesModal } from './ScenesModal.component.jsx';

--- a/src/components/scenegraph/SceneGraph.js
+++ b/src/components/scenegraph/SceneGraph.js
@@ -1,14 +1,11 @@
 /* eslint-disable no-unused-vars, react/no-danger */
+import classNames from 'classnames';
+import debounce from 'lodash-es/debounce';
 import PropTypes from 'prop-types';
 import React from 'react';
-import debounce from 'lodash-es/debounce';
-import classNames from 'classnames';
-
-import Entity from './Entity';
-import Toolbar from './Toolbar';
 import Events from '../../lib/Events';
+import Entity from './Entity';
 import { ToolbarWrapper } from './ToolbarWrapper';
-
 export default class SceneGraph extends React.Component {
   static propTypes = {
     id: PropTypes.string,
@@ -59,6 +56,7 @@ export default class SceneGraph extends React.Component {
   /**
    * Selected entity updated from somewhere else in the app.
    */
+
   componentDidUpdate(prevProps) {
     if (prevProps.selectedEntity !== this.props.selectedEntity) {
       this.selectEntity(this.props.selectedEntity);
@@ -207,7 +205,7 @@ export default class SceneGraph extends React.Component {
     if (!curr) {
       return false;
     }
-    while (curr !== undefined && curr.isEntity) {
+    while (curr !== undefined && curr?.isEntity) {
       if (!this.isExpanded(curr)) {
         return false;
       }

--- a/src/components/scenegraph/Toolbar.js
+++ b/src/components/scenegraph/Toolbar.js
@@ -1,11 +1,11 @@
-import { Button, ProfileButton, ScreenshotButton } from '../components';
-import { Cloud24Icon, Load24Icon, Save24Icon } from '../../icons';
-import { fileJSON, inputStreetmix } from '../../lib/toolbar';
-import { v4 as uuidv4 } from 'uuid';
 import React, { Component } from 'react';
-import Events from '../../lib/Events';
-import { saveBlob } from '../../lib/utils';
+import { v4 as uuidv4 } from 'uuid';
 import { uploadScene } from '../../api/scene';
+import { Cloud24Icon, Load24Icon, Save24Icon } from '../../icons';
+import Events from '../../lib/Events';
+import { inputStreetmix } from '../../lib/toolbar';
+import { saveBlob } from '../../lib/utils';
+import { Button, ProfileButton, ScreenshotButton } from '../components';
 
 // const LOCALSTORAGE_MOCAP_UI = "aframeinspectormocapuienabled";
 
@@ -324,6 +324,21 @@ export default class Toolbar extends Component {
               </Button>
               {this.state.isLoadActionActive && (
                 <div className="dropdownedButtons">
+                  <Button
+                    variant="white"
+                    onClick={() => Events.emit('openscenesmodal')}
+                  >
+                    <div
+                      className="icon"
+                      style={{
+                        display: 'flex',
+                        margin: '-2.5px 0px -2.5px -2px'
+                      }}
+                    >
+                      <Cloud24Icon />
+                    </div>
+                    Open
+                  </Button>
                   <Button onClick={inputStreetmix} variant="white">
                     <div
                       className="icon"
@@ -355,11 +370,11 @@ export default class Toolbar extends Component {
                     >
                       <input
                         type="file"
-                        onChange={fileJSON}
+                        onChange={this.fileJSON}
                         style={{ display: 'none' }}
                         accept=".js, .json, .txt"
                       />
-                      3DStreet JSON
+                      Load 3DStreet JSON
                     </label>
                   </Button>
                 </div>

--- a/src/icons/icons.jsx
+++ b/src/icons/icons.jsx
@@ -126,9 +126,9 @@ const Compass32Icon = () => (
     <path
       d="M12 12.5L7.5 24.5L21 20.5M12 12.5L25.5 8.5L21 20.5M12 12.5L21 20.5"
       stroke="#DBDBDB"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
   </svg>
 );
@@ -200,6 +200,23 @@ const DropdownArrowIcon = () => (
   </svg>
 );
 
+const Mangnifier20Icon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 20 20"
+    fill="none"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M8.3335 2.41675C5.15786 2.41675 2.5835 4.99111 2.5835 8.16675C2.5835 11.3424 5.15786 13.9167 8.3335 13.9167C9.60821 13.9167 10.786 13.502 11.7394 12.8L16.1365 17.1971C16.4294 17.49 16.9043 17.49 17.1972 17.1971C17.4901 16.9042 17.4901 16.4293 17.1972 16.1364L12.8219 11.7611C13.6113 10.7766 14.0835 9.52683 14.0835 8.16675C14.0835 4.99111 11.5091 2.41675 8.3335 2.41675ZM8.3335 3.91675C5.98629 3.91675 4.0835 5.81954 4.0835 8.16675C4.0835 10.514 5.98629 12.4167 8.3335 12.4167C10.6807 12.4167 12.5835 10.514 12.5835 8.16675C12.5835 5.81954 10.6807 3.91675 8.3335 3.91675Z"
+      fill="white"
+    />
+  </svg>
+);
+
 export {
   Camera32Icon,
   Save24Icon,
@@ -211,5 +228,6 @@ export {
   ArrowUp24Icon,
   CheckIcon,
   DropdownArrowIcon,
-  Cloud24Icon
+  Cloud24Icon,
+  Mangnifier20Icon
 };

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -9,5 +9,6 @@ export {
   ArrowUp24Icon,
   CheckIcon,
   DropdownArrowIcon,
-  Cloud24Icon
+  Cloud24Icon,
+  Mangnifier20Icon
 } from './icons.jsx';

--- a/src/lib/toolbar.js
+++ b/src/lib/toolbar.js
@@ -19,30 +19,26 @@ export function inputStreetmix() {
   Events.emit('entitycreated', streetContainerEl.sceneEl);
 }
 
-function getValidJSON(stringJSON) {
-  return stringJSON
-    .replace(/\'/g, '')
-    .replace(/\n/g, '')
-    .replace(/[\u0000-\u0019]+/g, '');
-}
-
-function createElementsFromJSON(streetJSONString) {
-  const validJSONString = getValidJSON(streetJSONString);
+export function createElementsForScenesFromJSON(streetData) {
   const streetContainerEl = document.getElementById('street-container');
+
   while (streetContainerEl.firstChild) {
     streetContainerEl.removeChild(streetContainerEl.lastChild);
   }
-  const streetObject = JSON.parse(validJSONString);
-  createEntities(streetObject.data, streetContainerEl);
-  // update sceneGraph
-  Events.emit('entitycreated', streetContainerEl.sceneEl);
-}
 
+  if (!Array.isArray(streetData)) {
+    console.error('Invalid data format. Expected an array.');
+    return;
+  }
+
+  createEntities(streetData, streetContainerEl);
+}
 export function fileJSON(event) {
   let reader = new FileReader();
-  console.log(event.target.files[0]);
+
   reader.onload = function () {
     createElementsFromJSON(reader.result);
   };
+
   reader.readAsText(event.target.files[0]);
 }

--- a/src/style/textureModal.styl
+++ b/src/style/textureModal.styl
@@ -225,19 +225,7 @@
   color: #fff !important;
 }
 
-.modal button {
-  appearance: none;
-  border-radius: 0;
-  box-shadow: none;
-  cursor: pointer;
-  display: inline-block;
-  font-size: 12px;
-  line-height: 1.8;
-  margin: 0 10px 0 0;
-  padding: 5px 10px;
-}
-
-.modal buttonfocus {
+.modal button:focus {
   outline: none;
 }
 

--- a/src/style/textureModal.styl
+++ b/src/style/textureModal.styl
@@ -102,36 +102,36 @@
   scrollbar-width: thin;
   scrollbar-color: #fff rgba(237, 235, 239, 0.5);
   margin-right: 20px;
-}
 
-.modal-scene-webkit-scrollbar {
-  width: 4px;
-  margin-right: 20px;
-}
+  &::-webkit-scrollbar {
+    width: 4px;
+    margin-right: 20px;
+  }
 
-.modal-scene-webkit-scrollbar-track {
-  background-color: rgba(237, 235, 239, 0.5);
-}
+  &::-webkit-scrollbar-track {
+    background-color: rgba(237, 235, 239, 0.5);
+  }
 
-.modal-scene-webkit-scrollbar-thumb {
-  background-color: #fff;
-  border-radius: 1px;
-}
+  &::-webkit-scrollbar-thumb {
+    background-color: #fff;
+    border-radius: 1px;
+  }
 
-.modal-scene-webkit-scrollbar-thumbvertical {
-  background-color: #fff;
-}
+  &::-webkit-scrollbar-thumb:vertical {
+    background-color: #fff;
+  }
 
-.modal-scene-webkit-scrollbar-thumbverticalafter {
-  content: '';
-  display: block;
-  height: 80px;
-}
+  &::-webkit-scrollbar-thumb:vertical::after {
+    content: '';
+    display: block;
+    height: 80px;
+  }
 
-.modal-scene-webkit-scrollbarafter {
-  content: '';
-  display: block;
-  height: 20px;
+  &::-webkit-scrollbar::after {
+    content: '';
+    display: block;
+    height: 20px;
+  }
 }
 
 .modal-footer {

--- a/src/style/textureModal.styl
+++ b/src/style/textureModal.styl
@@ -1,245 +1,392 @@
-.modal
-  animation animateopacity 0.2s ease-out
-  background-color rgba(0, 0, 0, 0.6)
-  display flex
-  height 100%
-  left 0
-  overflow auto
-  position fixed
-  top 0
-  width 100%
-  z-index 9
+.modal {
+  animation: animateopacity 0.2s ease-out;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  height: 100%;
+  left: 0;
+  overflow: auto;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 9;
+}
 
-.modal h3
-  font-size 18px
-  font-weight 100
-  margin 0.6em 0
+.modal h3 {
+  font-size: 18px;
+  font-weight: 100;
+  margin: 0.6em 0;
+}
 
-#textureModal .modal-content
-  height calc(100% - 50px)
-  width calc(100% - 50px)
+#textureModal .modal-content {
+  height: calc(100% - 50px);
+  width: calc(100% - 50px);
+}
 
-.modal-content
-  display: flex
-  flex-direction: column
-  row-gap: 30px
-  animation animatetop 0.2s ease-out
-  animation-duration 0.2s
-  animation-name animatetop
-  background-color rgb(34,34,34)
-  box-shadow 0 4px 8px 0 rgba(0, 0, 0, 0.5), 0 6px 20px 0 rgba(0, 0, 0, 0.5)
-  margin auto
-  overflow hidden
-  padding 0
-  border-radius 12px
-  height: fit-content
-  max-height: calc(100vh - 195px)
+.modal-content {
+  display: flex;
+  flex-direction: column;
+  row-gap: 30px;
+  animation: animatetop 0.2s ease-out;
+  animation-duration: 0.2s;
+  animation-name: animatetop;
+  background-color: rgb(34, 34, 34);
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.5), 0 6px 20px 0 rgba(0, 0, 0, 0.5);
+  margin: auto;
+  overflow: hidden;
+  padding: 0;
+  border-radius: 12px;
+  height: fit-content;
+  max-height: calc(100vh - 195px);
+}
 
-.close
-  display: flex
-  align-items: center
-  justify-content: center
+.close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: absolute;
-  top: 1.3438rem
+  top: 1.3438rem;
   right: 1.3438rem;
-  width: 32px
-  height: 32px
+  width: 32px;
+  height: 32px;
 
-  span 
-    position: absolute
-    display: block
-    width: 1px
-    height: 10.67px
-    background-color: rgba(219, 219, 219, 1)
-    transform: rotateZ(45deg)
-  
-  span:first-child 
-    transform: rotateZ(-45deg)
+  span {
+    position: absolute;
+    display: block;
+    width: 1px;
+    height: 10.67px;
+    background-color: rgba(219, 219, 219, 1);
+    transform: rotateZ(45deg);
+  }
 
-.closehover,
-.closefocus
-  color #08f
-  cursor pointer
-  text-decoration none
+  spanfirst-child {
+    transform: rotateZ(-45deg);
+  }
+}
 
-.modal-header
-  position: relative
-  color white
-  padding 2px 75px
+.closehover, .closefocus {
+  color: #08f;
+  cursor: pointer;
+  text-decoration: none;
+}
 
-.modal-body
-  display: flex
-  height: 100%
-  max-height: calc(100% - 140px)
-  overflow: hidden
-  padding 0px 40px
-  margin-bottom: 40px
+.modal-header {
+  position: relative;
+  color: white;
+  padding: 2px 75px;
+}
 
-.modal-footer
-  color white
-  padding 2px 16px
+.modal-body {
+  display: flex;
+  height: 100%;
+  max-height: calc(100% - 140px);
+  overflow: hidden;
+  padding: 0px 40px;
+  margin-bottom: 40px;
+}
+
+.modal-scene-header {
+  position: relative;
+  color: white;
+  padding: 2px 50px 2px 35px;
+}
+
+.modal-scene {
+  display: flex;
+  height: 100%;
+  max-height: calc(100% - 140px);
+  overflow: hidden;
+  padding: 0px 20px 0px 32px;
+  margin-bottom: 40px;
+  max-height: calc(100vh - 140px);
+  overflow-y: scroll;
+  scrollbar-width: thin;
+  scrollbar-color: #fff rgba(237, 235, 239, 0.5);
+  margin-right: 20px;
+}
+
+.modal-scene-webkit-scrollbar {
+  width: 4px;
+  margin-right: 20px;
+}
+
+.modal-scene-webkit-scrollbar-track {
+  background-color: rgba(237, 235, 239, 0.5);
+}
+
+.modal-scene-webkit-scrollbar-thumb {
+  background-color: #fff;
+  border-radius: 1px;
+}
+
+.modal-scene-webkit-scrollbar-thumbvertical {
+  background-color: #fff;
+}
+
+.modal-scene-webkit-scrollbar-thumbverticalafter {
+  content: '';
+  display: block;
+  height: 80px;
+}
+
+.modal-scene-webkit-scrollbarafter {
+  content: '';
+  display: block;
+  height: 20px;
+}
+
+.modal-footer {
+  color: white;
+  padding: 2px 16px;
+}
 
 /* Gallery */
-.gallery
-  background #232323
-  display flex
-  flex-wrap wrap
-  margin 15px auto 0
-  overflow auto
-  padding 15px 3px 3px
+.gallery {
+  background: #232323;
+  display: flex;
+  flex-wrap: wrap;
+  margin: 15px auto 0;
+  overflow: auto;
+  padding: 15px 3px 3px;
+}
 
-.newimage .gallery
-  padding 16px
+.newimage .gallery {
+  padding: 16px;
+}
 
-.gallery li
-  border-radius 2px
-  box-shadow 0 0 6px rgba(0, 0, 0, 0.6)
-  cursor pointer
-  margin 8px
-  overflow hidden
-  width 155px
+.gallery li {
+  border-radius: 2px;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.6);
+  cursor: pointer;
+  margin: 8px;
+  overflow: hidden;
+  width: 155px;
+}
 
-.gallery li.selected,
-.gallery li:hover
-  box-shadow 0 0 0 2px #1eaaf1
+.gallery li.selected, .gallery lihover {
+  box-shadow: 0 0 0 2px #1eaaf1;
+}
 
-.gallery li .detail
-  background-color #323232
-  margin 0
-  min-height 60px
-  padding 3px 10px
+.gallery li .detail {
+  background-color: #323232;
+  margin: 0;
+  min-height: 60px;
+  padding: 3px 10px;
+}
 
-.gallery li .button.fa-external-link
-  margin-left 136px
-  margin-top 5px
-  position fixed
+.gallery li .button.fa-external-link {
+  margin-left: 136px;
+  margin-top: 5px;
+  position: fixed;
+}
 
-.preview
-  padding 10px
-  width 150px
+.preview {
+  padding: 10px;
+  width: 150px;
+}
 
-.preview input
-  display block
-  margin 8px 0
-  width 144px
+.preview input {
+  display: block;
+  margin: 8px 0;
+  width: 144px;
+}
 
-.preview button
-  width 155px
+.preview button {
+  width: 155px;
+}
 
-.preview .detail .title
-  color #fff
-  display inline-block
-  max-width 155px
-  overflow hidden
-  text-overflow ellipsis
-  white-space nowrap
+.preview .detail .title {
+  color: #fff;
+  display: inline-block;
+  max-width: 155px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-.gallery li.selected .detail,
-.gallery li:hover .detail
-  background-color #444
+.gallery li.selected .detail, .gallery lihover .detail {
+  background-color: #444;
+}
 
-.gallery li .detail span
-  color #777
-  display block
-  margin-top 4px
-  overflow hidden
-  text-overflow ellipsis
-  white-space nowrap
-  width 140px
+.gallery li .detail span {
+  color: #777;
+  display: block;
+  margin-top: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 140px;
+}
 
-.gallery li.selected .detail span,
-.gallery li:hover .detail span
-  color #888
+.gallery li.selected .detail span, .gallery lihover .detail span {
+  color: #888;
+}
 
-.gallery li .detail span.title
-  color #fff !important
+.gallery li .detail span.title {
+  color: #fff !important;
+}
 
-.modal button
-  appearance none
-  border-radius 0
-  box-shadow none
-  cursor pointer
-  display inline-block
-  font-size 12px
-  line-height 1.8
-  margin 0 10px 0 0
-  padding 5px 10px
+.modal button {
+  appearance: none;
+  border-radius: 0;
+  box-shadow: none;
+  cursor: pointer;
+  display: inline-block;
+  font-size: 12px;
+  line-height: 1.8;
+  margin: 0 10px 0 0;
+  padding: 5px 10px;
+}
 
-.modal buttonfocus
-  outline none
+.modal buttonfocus {
+  outline: none;
+}
 
-.modal button
-  border none
-  color #fff
-  border-radius 11px
-  font-size 16px
+.modal button {
+  border: none;
+  color: #fff;
+  border-radius: 11px;
+  font-size: 16px;
+}
 
-.modal buttonhover,
-.modal button.hover
-  background-color #346392
-  text-shadow -1px 1px #27496d
+.modal buttonhover, .modal button.hover {
+  background-color: #346392;
+  text-shadow: -1px 1px #27496d;
+}
 
-.modal buttonactive,
-.modal button.active
-  background-color #27496d
-  text-shadow -1px 1px #193047
+.modal buttonactive, .modal button.active {
+  background-color: #27496d;
+  text-shadow: -1px 1px #193047;
+}
 
-.modal buttondisabled
-  background-color #888
-  cursor none
+.modal buttondisabled {
+  background-color: #888;
+  cursor: none;
+}
 
-.newimage
-  background-color #323232
-  color #bcbcbc
-  display flex
-  font-size 13px
-  justify-content space-between
-  margin-top 10px
-  overflow auto
-  padding 10px
+.modal button.loadBtn {
+  border-radius: 18px;
+  background: #774DEE;
+  margin: 0;
+}
 
-.newimage input
-  color #1eaaf1
-  padding 3px 5px
+.modal .loadBtnhover {
+  background-color: #6439df;
+  transition: all 0.3s;
+}
 
-.texture canvas + input
-  margin-left 5px
+.modal .loadBtn.active {
+  background-color: #5b37c0;
+  color: #b6b6b6;
+  transition: all 0.3s;
+}
 
-.texture .fa
-  padding-right 5px
+.modal .loadBtn.focus {
+  border: 1px solid #fff;
+}
 
-.texture .fa-external-link
-  font-size 14px
-  padding-top 2px
+.modal .loadBtn.disabled {
+  background-color: rgba(237, 235, 239, 0.5);
+  color: rgba(50, 50, 50, 0.4);
+  transition: all 0.3s;
+}
 
-.uploader-normal-button .hidden
-  display none
+.modal button.createScene {
+  border-radius: 18px;
+  padding: 12px 16px;
+  border: 1px solid #774DEE;
+  color: #774DEE;
+  background: transparent;
+  margin: 0;
+}
 
-.gallery a.fa.texture-link
-  box-shadow 0 0 14px -1px rgba(0, 0, 0, 0.75)
-  position fixed
+.modal .createScenehover {
+  color: #6439df;
+  border-color: #6439df;
+  transition: all 0.3s;
+}
 
-.assets.search
-  margin-top 10px
-  width 200px
+.modal .createScene.active {
+  color: #5b37c0;
+  border-color: #5b37c0;
+  transition: all 0.3s;
+}
 
-.assets.search .fa-search
-  top 7px
+.modal .createScene.focus {
+  border: 1px solid #fff;
+}
 
-.new_asset_options
-  margin 10px
+.modal .createScene.disabled {
+  color: rgba(237, 235, 239, 0.5);
+  border-color: rgba(237, 235, 239, 0.5);
+  transition: all 0.3s;
+}
 
-.new_asset_options > ul
-  margin-left 10px
-  padding 5px
+.newimage {
+  background-color: #323232;
+  color: #bcbcbc;
+  display: flex;
+  font-size: 13px;
+  justify-content: space-between;
+  margin-top: 10px;
+  overflow: auto;
+  padding: 10px;
+}
 
-.new_asset_options > ul > li
-  padding 10px 0
+.newimage input {
+  color: #1eaaf1;
+  padding: 3px 5px;
+}
 
-.new_asset_options .imageUrl
-  margin-left 5px
-  width 350px
+.texture canvas + input {
+  margin-left: 5px;
+}
 
-.texture canvas
-  border 1px solid $bglight
-  cursor pointer
+.texture .fa {
+  padding-right: 5px;
+}
+
+.texture .fa-external-link {
+  font-size: 14px;
+  padding-top: 2px;
+}
+
+.uploader-normal-button .hidden {
+  display: none;
+}
+
+.gallery a.fa.texture-link {
+  box-shadow: 0 0 14px -1px rgba(0, 0, 0, 0.75);
+  position: fixed;
+}
+
+.assets.search {
+  margin-top: 10px;
+  width: 200px;
+}
+
+.assets.search .fa-search {
+  top: 7px;
+}
+
+.new_asset_options {
+  margin: 10px;
+}
+
+.new_asset_options > ul {
+  margin-left: 10px;
+  padding: 5px;
+}
+
+.new_asset_options > ul > li {
+  padding: 10px 0;
+}
+
+.new_asset_options .imageUrl {
+  margin-left: 5px;
+  width: 350px;
+}
+
+.texture canvas {
+  border: 1px solid $bglight;
+  cursor: pointer;
+}


### PR DESCRIPTION
to merge:
- [x] Zade - styling issues - see below
- [x] Zade - remove search, "load new scene" and "create new scene" buttons for now (can just comment out, we can use later)
- [x] Zade - when clicking a scene, the scene should load and the dialog should close and the scene should be loaded
- [x] Zade - issue regarding loading new items when modal is loaded, instead of once upon authentication. (In other words, if the application is open, and you use firebase to change a title, for instance, the new scene title is not reflected in the list of scenes.)

Styling issues:
* Use hover states for cards: https://www.figma.com/file/W9jid3A0jgssnIKBFEvG38/3DStreet-2022?type=design&node-id=3131-48379&mode=design&t=y8oGhampc6fY6mWb-4
* Hover cursor for cards should be same as an `<a>` link a hand pointer
* Modal title "Open scene" is not aligned correctly, see https://www.figma.com/file/W9jid3A0jgssnIKBFEvG38/3DStreet-2022?type=design&node-id=5012-124637&mode=design&t=y8oGhampc6fY6mWb-4
* Also too much margin on the left, could be cut in half
* Cards should wrap text -- TBD
* Scrollbar should be visible per figma: https://www.figma.com/file/W9jid3A0jgssnIKBFEvG38/3DStreet-2022?type=design&node-id=5012-124637&mode=design&t=y8oGhampc6fY6mWb-4 (reduce screen size to see scrollbar)
* Visual notes: 
![image](https://github.com/3DStreet/3dstreet-editor/assets/470477/4f10887b-3a59-41f7-beae-37cc3eb1dadc)
