### PR TITLE
[parked] feat: firebase emulator

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,27 @@
+{
+  "functions": {
+    "source": "functions"
+  },
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "storage": {
+      "port": 9199
+    },
+    "ui": {
+      "enabled": true
+    },
+    "singleProjectMode": true
+  },
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "storage": {
+    "rules": "storage.rules"
+  }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,19 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "scenes",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "author",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "updateTimestamp",
+          "order": "DESCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}

--- a/src/services/firebase.js
+++ b/src/services/firebase.js
@@ -1,7 +1,7 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getStorage } from 'firebase/storage';
-import { getFirestore } from 'firebase/firestore';
+import { connectFirestoreEmulator, getFirestore } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: process.env.FIREBASE_API_KEY,
@@ -17,5 +17,14 @@ const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const storage = getStorage(app);
 const db = getFirestore(app);
+
+const isLocalhostAndMissingFirebaseEnv =
+  window.location.hostname === 'localhost' &&
+  (!process.env.FIREBASE_PROJECT_ID || !process.env.FIREBASE_API_KEY);
+
+if (isLocalhostAndMissingFirebaseEnv) {
+  console.log('Using Firestore Emulator');
+  connectFirestoreEmulator(db, 'localhost', 8080);
+}
 
 export { auth, storage, db };

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/ui-debug.log
+++ b/ui-debug.log
@@ -1,0 +1,2 @@
+Web / API server started at 127.0.0.1:4000
+Web / API server started at ::1:4000


### PR DESCRIPTION
relates to #291 

Hi!

Here is guide how to install and use firebase emulator:
- Install Firebase Tools:` npm install -g firebase-tools.`
- Initialize Firebase in your project: firebase init.
- Select Firestore, Authentication, and Storage during the initialization process.
- Install Java version 11 or higher (if you are using MacOS) - visit https://adoptium.net/ for installation.
- Add firebase.json to your project directory and security rules.
- To start the emulator, use the command: firebase emulators:start. It will run on http://localhost:4000/.
- To start the project locally, use: npm run start:dev. If you don’t have environment files, you can still test and create data in the emulator.

I have already added firebase emulator, but there are a lot of emulator files after executing run from cli. Maybe we need to hide it in gitignore ?