### PR TITLE
fix incorrect boundingBox

### DIFF
--- a/src/lib/EditorControls.js
+++ b/src/lib/EditorControls.js
@@ -1,57 +1,5 @@
 import debounce from 'lodash-es/debounce';
 
-THREE.Box3.prototype.expandByObject = (function () {
-  // Computes the world-axis-aligned bounding box of an object (including its children),
-  // accounting for both the object's, and children's, world transforms
-
-  var scope, i, l;
-
-  var v1 = new THREE.Vector3();
-
-  function traverse(node) {
-    var geometry = node.geometry;
-
-    if (geometry !== undefined) {
-      if (geometry.isGeometry) {
-        var vertices = geometry.vertices;
-
-        for (i = 0, l = vertices.length; i < l; i++) {
-          v1.copy(vertices[i]);
-          v1.applyMatrix4(node.matrixWorld);
-
-          if (isNaN(v1.x) || isNaN(v1.y) || isNaN(v1.z)) {
-            continue;
-          }
-          scope.expandByPoint(v1);
-        }
-      } else if (geometry.isBufferGeometry) {
-        var attribute = geometry.attributes.position;
-
-        if (attribute !== undefined) {
-          for (i = 0, l = attribute.count; i < l; i++) {
-            v1.fromBufferAttribute(attribute, i).applyMatrix4(node.matrixWorld);
-
-            if (isNaN(v1.x) || isNaN(v1.y) || isNaN(v1.z)) {
-              continue;
-            }
-            scope.expandByPoint(v1);
-          }
-        }
-      }
-    }
-  }
-
-  return function expandByObject(object) {
-    scope = this;
-
-    object.updateMatrixWorld(true);
-
-    object.traverse(traverse);
-
-    return this;
-  };
-})();
-
 /**
  * @author qiao / https://github.com/qiao
  * @author mrdoob / http://mrdoob.com


### PR DESCRIPTION
Vincent Fretin from Aframe advise to remove the old function `Box3.prototype.expandByObject` to correctly define `boundingBox`: 
https://github.com/aframevr/aframe-inspector/pull/686 
I did this in the 3DStreet-editor repository in this PR and now the `boundingBox` is defined correctly for pedestrians and for almost all other objects... except the tram. I don't know why yet. It’s interesting that in a clean scene with two objects - a tram and a pedestrian, the boundingBox is determined correctly for both