### PR TITLE
add newScene call to scene loading methods

### DIFF
--- a/src/lib/toolbar.js
+++ b/src/lib/toolbar.js
@@ -6,31 +6,31 @@ export function inputStreetmix() {
     'https://streetmix.net/kfarr/3/example-street'
   );
 
+  // clrear scene data, create new blank scene.
+  // clearMetadata = true, clearUrlHash = false
+  STREET.utils.newScene(true, false);
+
   setTimeout(function () {
     window.location.hash = streetmixURL;
   });
 
-  const streetContainerEl = document.getElementById('street-container');
-
-  while (streetContainerEl.firstChild) {
-    streetContainerEl.removeChild(streetContainerEl.lastChild);
-  }
-
-  streetContainerEl.innerHTML =
-    '<a-entity street streetmix-loader="streetmixStreetURL: ' +
-    streetmixURL +
-    '""></a-entity>';
+  const streetContainerEl = document.getElementById('default-street');
+  streetContainerEl.setAttribute(
+    'streetmix-loader',
+    'streetmixStreetURL',
+    streetmixURL
+  );
 
   // update sceneGraph
   Events.emit('entitycreated', streetContainerEl.sceneEl);
 }
 
 export function createElementsForScenesFromJSON(streetData) {
-  const streetContainerEl = document.getElementById('street-container');
+  // clrear scene data, create new blank scene.
+  // clearMetadata = true, clearUrlHash = true, addDefaultStreet = false
+  STREET.utils.newScene(true, false, false);
 
-  while (streetContainerEl.firstChild) {
-    streetContainerEl.removeChild(streetContainerEl.lastChild);
-  }
+  const streetContainerEl = document.getElementById('street-container');
 
   if (!Array.isArray(streetData)) {
     console.error('Invalid data format. Expected an array.');


### PR DESCRIPTION
Added a call to the `newScene` function that creates a blank Scene to the scene loading methods in Editor toolbar, instead of the old code. `newScene` function can be called via `STREET.utils.newScene` to create a blank Scene.
Need to make changes from this PR first: https://github.com/3DStreet/3dstreet/pull/509