### PR TITLE
Basic user claim access

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx lint-staged

--- a/README.md
+++ b/README.md
@@ -48,3 +48,13 @@ Note: If you are deploying to a development server and want to use development (
 * Create a new GitHub release here: https://github.com/3DStreet/3dstreet-editor/releases/new. Choose the tag you used above. (If needed for the title simply use the new version such as "1.1" or "1.1.0")
 * Click to automatically "generate release notes." Consider summarizing a few key changes to put at the top.
 * Update CHANGELOG.md with a quick summary of the auto generated release notes under the "Major improvement" heading.
+
+## Editor Auth Notes
+
+* For testing we have a basic access control system using Firebase auth "claims." By default a user have no claims. They can be added in JSON format via direct database editing for a given user's claims field. Example claim for a user with beta access on a Pro plan:
+```
+{
+  "plan": "PRO",
+  "beta": true
+}
+```

--- a/src/api/user.js
+++ b/src/api/user.js
@@ -20,9 +20,51 @@ const createInitialUsersCollection = async (author) => {
   });
 };
 
+const isUserPro = async (user) => {
+  if(user) {
+    user.getIdToken(true)
+    .then(() => {
+      user.getIdTokenResult().then(idTokenResult => {
+        if (idTokenResult.claims.plan === "PRO") {
+          console.log("PRO PLAN USER")
+          return true;
+        } else {
+          console.log("FREE PLAN USER")
+          return false;
+        }
+      })
+    })
+  } else {
+    console.log('refreshIdTokens : currentUser not set')
+  }
+  return false;
+};
+
+const isUserBeta = async (user) => {
+  if(user) {
+    user.getIdToken(true)
+    .then(() => {
+      user.getIdTokenResult().then(idTokenResult => {
+        if (!!idTokenResult.claims.beta) {
+          console.log("BETA USER")
+          return true;
+        } else {
+          console.log("NOT BETA USER")
+          return false;
+        }
+      })
+    })
+  } else {
+    console.log('refreshIdTokens : currentUser not set')
+  }
+  return false;
+};
+
 export {
   userFindByUidQuery,
   getUserByQuery,
   createInitialUsersCollection,
-  getScenes
+  getScenes,
+  isUserPro,
+  isUserBeta
 };

--- a/src/contexts/Auth.context.js
+++ b/src/contexts/Auth.context.js
@@ -6,6 +6,7 @@ import {
 } from '../api';
 import { auth } from '../services/firebase';
 import PropTypes from 'prop-types';
+import { isUserPro, isUserBeta } from '../api/user';
 
 const AuthContext = createContext({
   currentUser: null,
@@ -21,6 +22,10 @@ const AuthProvider = ({ children }) => {
         localStorage.removeItem('token');
       } else {
         setCurrentUser(user);
+        const isPro = await isUserPro(user);
+        setCurrentUser({ ...user, isPro })
+        const isBeta = await isUserBeta(user);
+        setCurrentUser({ ...user, isBeta})
         localStorage.setItem('token', await user.getIdToken());
 
         try {


### PR DESCRIPTION
This is a very basic access control system using Firebase auth "claims." By default a user have no claims. They can be added in JSON format via direct database editing.

Example claim for a user with beta access on a Pro plan
```
{
  "plan": "PRO",
  "beta": true
}
```

Example of this claim being edited for a user using Firefoo app [1]
![image](https://github.com/3DStreet/3dstreet-editor/assets/470477/fdbe0487-573b-49a1-aa51-3089bb35b464)

[1] https://www.firefoo.app/  (paid)
[2] Open-source alternative https://github.com/thanhlmm/refi-app
